### PR TITLE
Substitute bun x for bunx

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	],
 	"scripts": {
 		"setup:hooks": "bash scripts/install-git-hooks.sh",
-		"build:native": "bunx @napi-rs/cli build --cwd crates/native --platform --release",
+		"build:native": "bun x @napi-rs/cli build --cwd crates/native --platform --release",
 		"example:echo": "bun run examples/echo-playground/server.ts",
 		"example:echo:cert": "mkdir -p examples/echo-playground/certs && openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -days 10 -nodes -keyout examples/echo-playground/certs/key.pem -out examples/echo-playground/certs/cert.pem -subj '/CN=localhost' -addext 'subjectAltName = DNS:localhost,IP:127.0.0.1'",
 		"example:echo:docker": "bash examples/echo-playground/run-docker.sh",


### PR DESCRIPTION
Avoid 

```
bun run build:native
$ bunx @napi-rs/cli build --cwd crates/native --platform --release
/usr/bin/bash: line 1: bunx: command not found
error: script "build:native" exited with code 127
```