### PR TITLE
Register fuzz and IWA workflow dispatches

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,46 @@
+name: fuzz
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions: {}
+
+concurrency:
+  group: fuzz-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable action resolved 2026-07-21
+        with:
+          toolchain: 1.95.0
+          components: llvm-tools-preview
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+      - name: Install pinned fuzz tooling
+        run: rustup run 1.95.0 cargo install cargo-fuzz --locked --version 0.13.1
+      - name: Install deps
+        run: bun install --frozen-lockfile
+      - name: Compile-check fuzz targets (PR-time safety net)
+        run: |
+          rustup run 1.95.0 cargo fuzz build --fuzz-dir tools/fuzz --sanitizer none || \
+          (cd tools/fuzz && rustup run 1.95.0 cargo check --all-targets)
+      - name: Scheduled fuzz smoke
+        run: bun run fuzz:release-smoke
+      - name: Upload fuzz evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 resolved 2026-07-22
+        with:
+          name: fuzz-evidence
+          path: |
+            .release-evidence/fuzz/
+            tools/fuzz/corpora/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/iwa.yml
+++ b/.github/workflows/iwa.yml
@@ -1,0 +1,144 @@
+# CI: Test the WASM WebTransport server running inside a Chromium Isolated Web App (IWA).
+#
+# Direct Sockets UDPSocket requires an IWA with the direct-sockets permission,
+# which is Chromium-only and behind flags. This workflow automates the packaging
+# and runs a headless Chromium to verify the in-browser server actually works.
+
+name: IWA Interop
+on:
+  schedule:
+    - cron: '0 4 * * *' # Daily at 4am
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: iwa-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  iwa-interop:
+    name: IWA Browser Server (Direct Sockets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      contents: read
+    env:
+      WEBTRANSPORT_SUPPRESS_INSECURE_SKIP_VERIFY_WARN: "1"
+      CC_wasm32_unknown_unknown: clang
+      AR_wasm32_unknown_unknown: llvm-ar
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable action resolved 2026-07-21
+        with:
+          toolchain: 1.95.0
+          targets: wasm32-unknown-unknown
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 resolved 2026-07-22
+        with:
+          node-version: "22.23.1"
+      
+      - name: Install wasm C toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang lld llvm xvfb
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.121 --locked
+      
+      - name: Install root deps
+        run: bun install --frozen-lockfile
+      
+      - name: Build web-target wasm
+        run: bun run build:wasm:web
+      
+      - name: Bundle wasm JS for IWA
+        run: |
+          cd packages/webtransport
+          bun build src/wasm.ts --outfile ../../examples/webtransport-wasm-iwa/vendor/webtransport-wasm.js --target browser --format esm
+          
+      - name: Setup IWA packaging tools
+        run: |
+          npm install --no-save --ignore-scripts wbn@0.0.9 wbn-sign@0.3.1 playwright@1.58.2
+          timeout 10m npx playwright@1.58.2 install chromium chrome-beta
+
+      - name: Build native addon for Chromium interop
+        run: bun run build:native
+
+      - name: Prove Chromium against the native addon server
+        run: |
+          cd tools/interop
+          INTEROP_EVIDENCE=1 npx playwright@1.58.2 test
+
+      - name: Build node-target WASM for Chromium interop
+        run: bun run build:wasm
+
+      - name: Prove Chromium against the WASM server under Bun
+        run: |
+          cd tools/interop
+          INTEROP_EVIDENCE=1 npx playwright@1.58.2 test -c playwright.wasm.config.ts
+
+      - name: Prove the seeded user-space UDP fault matrix
+        env:
+          WT_FAULT_EVIDENCE_PATH: ${{ github.workspace }}/.release-evidence/interop/fault-matrix.json
+        run: |
+          cd tools/interop
+          npx playwright@1.58.2 test -c playwright.fault.config.ts
+        
+      - name: Package IWA
+        run: |
+          mkdir -p .release-evidence/iwa
+          openssl genpkey -algorithm Ed25519 -out "$RUNNER_TEMP/iwa-signing.key.pem"
+          npx wbn --dir examples/webtransport-wasm-iwa --output .release-evidence/iwa/webtransport-wasm-iwa.wbn --formatVersion b2
+          node -e '
+            const { NodeCryptoSigningStrategy, IntegrityBlockSigner, WebBundleId } = require("wbn-sign");
+            const crypto = require("node:crypto"), fs = require("node:fs");
+            const path = require("node:path");
+            const key = crypto.createPrivateKey(fs.readFileSync(path.join(process.env.RUNNER_TEMP, "iwa-signing.key.pem")));
+            const origin = new WebBundleId(key).serializeWithIsolatedWebAppOrigin();
+            fs.writeFileSync(".release-evidence/iwa/origin.txt", origin);
+            new IntegrityBlockSigner(fs.readFileSync(".release-evidence/iwa/webtransport-wasm-iwa.wbn"),
+              new WebBundleId(key).serialize(),
+              [new NodeCryptoSigningStrategy(key)]
+            ).sign().then(({ signedWebBundle }) =>
+              fs.writeFileSync(".release-evidence/iwa/webtransport-wasm-iwa.swbn", signedWebBundle));
+          '
+          
+      - name: Run IWA Playwright Test
+        env:
+          WT_IWA_BUNDLE_PATH: .release-evidence/iwa/webtransport-wasm-iwa.swbn
+          WT_IWA_UNSIGNED_BUNDLE_PATH: .release-evidence/iwa/webtransport-wasm-iwa.wbn
+          WT_IWA_ORIGIN_PATH: .release-evidence/iwa/origin.txt
+          WT_IWA_PROFILE_DIR: ${{ runner.temp }}/iwa-chromium-profile
+          WT_IWA_EVIDENCE_PATH: .release-evidence/iwa/evidence.json
+          WT_PLAYWRIGHT_VERSION: "1.58.2"
+        run: |
+          xvfb-run node tools/interop/run-iwa.mjs
+
+      - name: Run IWA Playwright Test on Chrome Beta
+        env:
+          WT_IWA_BUNDLE_PATH: .release-evidence/iwa/webtransport-wasm-iwa.swbn
+          WT_IWA_UNSIGNED_BUNDLE_PATH: .release-evidence/iwa/webtransport-wasm-iwa.wbn
+          WT_IWA_ORIGIN_PATH: .release-evidence/iwa/origin.txt
+          WT_IWA_PROFILE_DIR: ${{ runner.temp }}/iwa-chrome-beta-profile
+          WT_IWA_EVIDENCE_PATH: .release-evidence/iwa/evidence-chrome-beta.json
+          WT_IWA_BROWSER_CHANNEL: chrome-beta
+          WT_PLAYWRIGHT_VERSION: "1.58.2"
+        run: |
+          xvfb-run node tools/interop/run-iwa.mjs
+
+      - name: Upload immutable IWA evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 resolved 2026-07-22
+        with:
+          name: iwa-proof-${{ github.sha }}
+          path: |
+            .release-evidence/iwa/evidence.json
+            .release-evidence/iwa/evidence-chrome-beta.json
+            .release-evidence/iwa/origin.txt
+            .release-evidence/iwa/webtransport-wasm-iwa.wbn
+            .release-evidence/iwa/webtransport-wasm-iwa.swbn
+            .release-evidence/interop/fault-matrix.json
+            tools/interop/interop-evidence.json
+            tools/interop/interop-evidence-wasm.json
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary
- register the existing fuzz workflow on the default branch
- register the existing IWA interop workflow on the default branch
- preserve the current workflow bodies and explicit candidate-ref dispatch model

## Verification
- YAML parse passed for both workflow files
- TypeScript typecheck passed
- Rust fmt check passed under 1.95.0
- Rust workspace check passed under 1.95.0
