### PR TITLE
fix: bounded backpressure on full stream queues; pin-only serverCertificateHashes verifier (no CryptoProvider panic)

### DIFF
--- a/crates/native/src/client.rs
+++ b/crates/native/src/client.rs
@@ -425,6 +425,7 @@ impl ClientSessionHandle {
                 max_global,
                 max_session,
                 max_stream,
+                backpressure_timeout_ms,
             }
         };
 
@@ -865,13 +866,15 @@ fn build_client_tls_config(
             .dangerous()
             .set_certificate_verifier(Arc::new(InsecureVerifier));
     } else if !pinned_hashes.is_empty() {
-        let base = rustls::client::WebPkiServerVerifier::builder(Arc::clone(&root_store))
-            .build()
-            .map_err(|e| format!("E_TLS: failed to build certificate verifier: {}", e))?;
+        // W3C serverCertificateHashes semantics: the pin REPLACES chain trust
+        // (self-signed short-lived certs are the intended use). Chain building
+        // via WebPkiServerVerifier is wrong here twice over: it panics when no
+        // process-level CryptoProvider is installed (rustls builder_with_provider
+        // configs never install one), and an empty/unrelated root store can
+        // never validate the self-signed leaf the pin points at.
         config
             .dangerous()
             .set_certificate_verifier(Arc::new(PinnedCertVerifier {
-                inner: base,
                 pins: pinned_hashes.to_vec(),
             }));
     }
@@ -933,7 +936,6 @@ impl rustls::client::danger::ServerCertVerifier for InsecureVerifier {
 
 #[derive(Debug)]
 struct PinnedCertVerifier {
-    inner: Arc<dyn rustls::client::danger::ServerCertVerifier>,
     pins: Vec<[u8; 32]>,
 }
 
@@ -941,18 +943,11 @@ impl rustls::client::danger::ServerCertVerifier for PinnedCertVerifier {
     fn verify_server_cert(
         &self,
         end_entity: &rustls::pki_types::CertificateDer<'_>,
-        intermediates: &[rustls::pki_types::CertificateDer<'_>],
-        server_name: &rustls::pki_types::ServerName<'_>,
-        ocsp_response: &[u8],
-        now: rustls::pki_types::UnixTime,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
     ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
-        self.inner.verify_server_cert(
-            end_entity,
-            intermediates,
-            server_name,
-            ocsp_response,
-            now,
-        )?;
         let mut hasher = Sha256::new();
         hasher.update(end_entity.as_ref());
         let actual: [u8; 32] = hasher.finalize().into();
@@ -971,7 +966,12 @@ impl rustls::client::danger::ServerCertVerifier for PinnedCertVerifier {
         cert: &rustls::pki_types::CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls12_signature(message, cert, dss)
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
     }
 
     fn verify_tls13_signature(
@@ -980,11 +980,18 @@ impl rustls::client::danger::ServerCertVerifier for PinnedCertVerifier {
         cert: &rustls::pki_types::CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
-        self.inner.verify_tls13_signature(message, cert, dss)
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+        )
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        self.inner.supported_verify_schemes()
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
     }
 }
 

--- a/crates/native/src/client_stream.rs
+++ b/crates/native/src/client_stream.rs
@@ -57,6 +57,7 @@ pub struct StreamBudget {
     pub max_global: u64,
     pub max_session: u64,
     pub max_stream: u64,
+    pub backpressure_timeout_ms: u64,
 }
 
 impl StreamBudget {
@@ -100,6 +101,32 @@ impl StreamBudget {
             return false;
         }
         true
+    }
+
+    /// Reserve, waiting up to `backpressure_timeout_ms` for capacity to drain.
+    /// Applies backpressure instead of failing on a momentarily-full queue.
+    /// Returns false only on timeout. Updates backpressure wait/timeout metrics.
+    pub async fn reserve_or_wait(&self, n: u64) -> bool {
+        if self.try_reserve(n) {
+            return true;
+        }
+        self.server_metrics
+            .backpressure_wait_count
+            .fetch_add(1, Ordering::Relaxed);
+        let deadline = tokio::time::Instant::now()
+            + tokio::time::Duration::from_millis(self.backpressure_timeout_ms);
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+            if self.try_reserve(n) {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                self.server_metrics
+                    .backpressure_timeout_count
+                    .fetch_add(1, Ordering::Relaxed);
+                return false;
+            }
+        }
     }
 
     pub fn release(&self, n: u64) {
@@ -240,8 +267,8 @@ impl ClientBidiStreamHandle {
         }
         let sz = bytes.len() as u64;
         if let Some(ref b) = self.budget {
-            if !b.try_reserve(sz) {
-                return Err(napi::Error::from_reason("E_QUEUE_FULL"));
+            if !b.reserve_or_wait(sz).await {
+                return Err(napi::Error::from_reason("E_BACKPRESSURE_TIMEOUT"));
             }
         }
         if tx.send(StreamCmd::Data(bytes)).await.is_err() {
@@ -360,8 +387,8 @@ impl ClientUniSendHandle {
         }
         let sz = bytes.len() as u64;
         if let Some(ref b) = self.budget {
-            if !b.try_reserve(sz) {
-                return Err(napi::Error::from_reason("E_QUEUE_FULL"));
+            if !b.reserve_or_wait(sz).await {
+                return Err(napi::Error::from_reason("E_BACKPRESSURE_TIMEOUT"));
             }
         }
         if tx.send(StreamCmd::Data(bytes)).await.is_err() {
@@ -540,7 +567,7 @@ pub fn spawn_bidi_bridge_on(
                         Ok(Some(n)) => {
                             let sz = n as u64;
                             if let Some(ref b) = read_budget {
-                                if !b.try_reserve(sz) {
+                                if !b.reserve_or_wait(sz).await {
                                     recv_stream.stop(VarInt::from_u32(0));
                                     break;
                                 }
@@ -781,7 +808,7 @@ pub fn spawn_uni_recv_bridge_on(
                         Ok(Some(n)) => {
                             let sz = n as u64;
                             if let Some(ref b) = budget {
-                                if !b.try_reserve(sz) {
+                                if !b.reserve_or_wait(sz).await {
                                     recv_stream.stop(VarInt::from_u32(0));
                                     break;
                                 }

--- a/crates/native/src/lib.rs
+++ b/crates/native/src/lib.rs
@@ -649,6 +649,7 @@ pub(crate) fn spawn_wtransport_server(
                                                                 max_global: lim_bidi.max_queued_bytes_global,
                                                                 max_session: lim_bidi.max_queued_bytes_per_session,
                                                                 max_stream: lim_bidi.max_queued_bytes_per_stream,
+                                                                backpressure_timeout_ms: lim_bidi.backpressure_timeout_ms,
                                                             };
                                                             let (read_rx, write_tx, stop_tx, write_err_slot, read_err_slot) = crate::client_stream::spawn_bidi_bridge(send, recv, Some(guard), Some(budget.clone()));
                                                             let handle = crate::client_stream::ClientBidiStreamHandle::new_with_budget_and_slot(read_rx, write_tx, stop_tx, Some(budget), write_err_slot, read_err_slot);
@@ -709,6 +710,7 @@ pub(crate) fn spawn_wtransport_server(
                                                                 max_global: lim_uni.max_queued_bytes_global,
                                                                 max_session: lim_uni.max_queued_bytes_per_session,
                                                                 max_stream: lim_uni.max_queued_bytes_per_stream,
+                                                                backpressure_timeout_ms: lim_uni.backpressure_timeout_ms,
                                                             };
                                                             let (read_rx, stop_tx, read_err_slot) = crate::client_stream::spawn_uni_recv_bridge(recv, Some(guard), Some(budget.clone()));
                                                             let handle = crate::client_stream::ClientUniRecvHandle::new_with_budget_and_slot(read_rx, stop_tx, Some(budget), read_err_slot);
@@ -770,6 +772,7 @@ pub(crate) fn spawn_wtransport_server(
                                                                     max_global: lim_create_bi.max_queued_bytes_global,
                                                                     max_session: lim_create_bi.max_queued_bytes_per_session,
                                                                     max_stream: lim_create_bi.max_queued_bytes_per_stream,
+                                                                backpressure_timeout_ms: lim_create_bi.backpressure_timeout_ms,
                                                                 };
                                                                 let (read_rx, write_tx, stop_tx, write_err_slot, read_err_slot) =
                                                                     crate::client_stream::spawn_bidi_bridge(send, recv, Some(guard), Some(budget.clone()));
@@ -837,6 +840,7 @@ pub(crate) fn spawn_wtransport_server(
                                                                         max_global: lim_create_uni.max_queued_bytes_global,
                                                                         max_session: lim_create_uni.max_queued_bytes_per_session,
                                                                         max_stream: lim_create_uni.max_queued_bytes_per_stream,
+                                                                backpressure_timeout_ms: lim_create_uni.backpressure_timeout_ms,
                                                                     };
                                                                     let (write_tx, write_err_slot) = crate::client_stream::spawn_uni_send_bridge(send, Some(guard), Some(budget.clone()));
                                                                     let handle = crate::client_stream::ClientUniSendHandle::new_with_budget_and_slot(write_tx, Some(budget), write_err_slot);


### PR DESCRIPTION
Fixes #15, fixes #16.

## What

Two fixes in the native crate, `+63/-25` across `client.rs`, `client_stream.rs`, `lib.rs`:

**1. Stream backpressure (#15).** `StreamBudget` gains a `backpressure_timeout_ms` field and a
`reserve_or_wait()` method: the fast path is the existing `try_reserve`, and on a full queue it
waits (1 ms poll) up to `backpressureTimeoutMs`, incrementing the existing
`backpressure_wait_count` / `backpressure_timeout_count` metrics that were previously never
updated on this path. All four reserve sites are converted:

- both JS-facing `write()` paths (bidi/uni) now apply the bounded wait and fail with
  `E_BACKPRESSURE_TIMEOUT` only after it expires — instead of an instant `E_QUEUE_FULL` the
  moment `maxQueuedBytesPerStream` (default 256 KiB) fills;
- both native receive tasks now wait instead of `recv_stream.stop()` when the JS reader lags,
  so a slow consumer throttles the sender via QUIC flow control instead of killing the stream.

**2. serverCertificateHashes (#16).** `PinnedCertVerifier` no longer wraps
`WebPkiServerVerifier`: that builder reads the process-level rustls `CryptoProvider`, which is
never installed (all configs here use `builder_with_provider`), producing the panic in #16 —
and chain validation can never succeed for the self-signed certificates certificate pinning
exists to serve. Per W3C WebTransport semantics the pin replaces chain trust, so the verifier
is now pin-only (SHA-256 of the end-entity DER against the provided set), with TLS 1.2/1.3
signature verification delegated explicitly to the ring provider. The wrong-hash rejection
path is unchanged.

## Verification

A/B on the same machine (Bun 1.3.14, linux-x64), identical scripts from the two issues, the
patch being the only variable:

| Test | 0.3.0 | patched |
|---|---|---|
| full-speed 64 MiB write + independent sha256 both ends | fails after ~640 KiB | completes, 72 MiB/s, hashes match |
| slow reader (5 ms/read) | fails after ~384 KiB | completes, sender throttled to reader pace |
| pin with correct sha-256 | `E_HANDSHAKE_TIMEOUT` + native panic | connects, no panic |
| pin with wrong hash | rejected | rejected (unchanged) |

Mechanism check: under the slow reader, `metricsSnapshot().backpressureWaitCount` advances
0 → 1 with `backpressureTimeoutCount` 0, i.e. the wait path engages rather than merely not
erroring.

`bun run test`: **184 pass / 0 fail** on the patched native.

Notes: the `E_BACKPRESSURE_TIMEOUT` branch is hard to exercise end-to-end on loopback because
default transport flow-control windows absorb a stalled reader's payload into native memory
first (that buffering may itself be worth a look — happy to file separately). Naming a
different error than `E_QUEUE_FULL` for the post-wait failure seemed more truthful, but easy
to change if you prefer the old code for compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
